### PR TITLE
README: add note about remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,25 +8,27 @@ Command line utility for creating new releases of libuv.
 branch that will be used to create the release.
 2. Currently, the release tool requires Node.js v0.10.x. You may want to use
 something like `nvm` to change Node versions.
-3. Run `node ./release.js --version x.x.x --dir path`, where `x.x.x` is the
-version of libuv you are creating, and `path` is the location of the libuv core
-repository on your machine. This will perform a few tasks, such as updating the
-libuv `AUTHORS` file if necessary. Review any changes made to libuv before
-continuing.
-4. Run `node ./release.js --version x.x.x --dir path --continue`. `x.x.x` and
-`path` have the same meaning as in the previous step. The `--continue` flag
-tells the release tool to continue work on the release started in the previous
-step. If you need to cancel a release that has been started, you can substitute
-`--abort` for `--continue` at any time. At this time, you should see the
-CHANGELOG for the proposed release. Review the CHANGELOG for correctness. Remove
-the first commit, which should mention adding the SHA to CHANGELOG. Optionally,
-you may remove any commits that were made and then reverted in this release, as
-they cancel each other out. Once the CHANGELOG looks good, save the changes. You
-will also need to sign the release using your GPG key.
-5. Run `node ./release.js --version x.x.x --dir path --continue` again. This
-updates the website, pushes the tag and branch, signs the tarball, etc. You can
-verify that this step worked by checking `http://dist.libuv.org/dist/vx.x.x`,
-which should include `.tar.gz` and `.tar.gz.sign` files.
+3. Run `node ./release.js --version x.x.x --dir path --remote name`, where
+`x.x.x` is the version of libuv you are creating, `path` is the location of
+the libuv core repository on your machine, and `name` is the libuv core git
+remote. This will perform a few tasks, such as updating the libuv `AUTHORS`
+file if necessary. Review any changes made to libuv before continuing.
+4. Run `node ./release.js --version x.x.x --dir path --remote name --continue`.
+`x.x.x`, `path`, and `name` have the same meaning as in the previous step. The
+`--continue` flag tells the release tool to continue work on the release started
+in the previous step. If you need to cancel a release that has been started, you
+can substitute `--abort` for `--continue` at any time. At this time, you should
+see the CHANGELOG for the proposed release. Review the CHANGELOG for
+correctness. Remove the first commit, which should mention adding the SHA to
+CHANGELOG. Optionally, you may remove any commits that were made and then
+reverted in this release, as they cancel each other out. Once the CHANGELOG
+looks good, save the changes. You will also need to sign the release using your
+GPG key.
+5. Run `node ./release.js --version x.x.x --dir path --remote name --continue`
+again. This updates the website, pushes the tag and branch, signs the tarball,
+etc. You can verify that this step worked by checking
+`http://dist.libuv.org/dist/vx.x.x`, which should include `.tar.gz` and
+`.tar.gz.sign` files.
 6. Next, we will generate the Windows executables. Log in to
 [AppVeyor](https://ci.appveyor.com/login). You will need an account for this.
 If you are creating an account, you will also need to add the libuv/libuv


### PR DESCRIPTION
This commit adds information about the git remote that the tool works with. Specifying the remote prevents confusion if the releaser does not have `libuv/libuv` named 'origin'.

This happened to me with v1.10.0, as I have `libuv/libuv` named 'upstream'.
