### PR TITLE
support patch-series format in PR titles

### DIFF
--- a/lib/relnotes.js
+++ b/lib/relnotes.js
@@ -85,7 +85,7 @@ function generate(git, version, baseVersion, cb) {
         return cb2(err);
 
       // Strip PR numbers from titles
-      stdout = stdout.replace(/\s*\(#\d+\)\s*/g, ' ');
+      stdout = stdout.replace(/\s*\(#\d+(?: \d+\/\d+)?\)\s*/g, ' ');
       if (prefix) {
         stdout = prefix + stdout.replace(/\r?\n/g, '\n' + prefix);
       }


### PR DESCRIPTION
Since we don't support merge commits, it is helpful in rare cases to be
able to land a sequence of patches as a series. This requires manual
intervention to format the commit message, as can be seen in
https://github.com/libuv/libuv/pull/3540.

    uv: register UV_RENAME event for _RFIM_UNLINK (#3540 2/3)